### PR TITLE
Fixed age gap in display function

### DIFF
--- a/wisdom_tree/main.py
+++ b/wisdom_tree/main.py
@@ -357,7 +357,7 @@ class tree:
             self.artfile = str(RES_FOLDER/"p4.txt")
         if self.age >= 30 and self.age < 40:
             self.artfile = str(RES_FOLDER/"p5.txt")
-        if self.age >= 40 and self.age < 60:
+        if self.age >= 40 and self.age < 70:
             self.artfile = str(RES_FOLDER/"p6.txt")
         if self.age >= 70 and self.age < 120:
             self.artfile = str(RES_FOLDER/"p7.txt")


### PR DESCRIPTION
The display function had a gap when determining the artfile based on the age of the tree. If the program was started with the age somewhere between 60 and 70, the artfile was never set and an exception was raised.